### PR TITLE
Remove babel-polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-  "presets": ["env"]
+  "presets": ["@babel/preset-env"],
+  "plugins": [
+    "@babel/plugin-transform-object-assign",
+    "@babel/plugin-transform-runtime"
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-    - '4.0'
     - '7.0'
 after_success: bash <(curl -s https://codecov.io/bash)
 sudo: false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remark-task-list",
   "description": "Toggle task list items and reference them by IDs.",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "keywords": [
     "remark",
     "remark-plugin",
@@ -16,20 +16,23 @@
     "url": "https://markhudnall.com"
   },
   "scripts": {
-    "test": "npm run babel && mocha --compilers js:babel-core/register test/index_test.js",
+    "test": "npm run babel && mocha --require @babel/register test/index_test.js",
     "babel": "babel src --out-dir lib",
     "prepublish": "npm run babel"
   },
   "main": "lib/index.js",
   "dependencies": {
-    "babel-polyfill": "^6.23.0",
+    "@babel/runtime": "^7.4.4",
     "unist-util-map": "^1.0.3"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-core": "^6.25.0",
-    "babel-preset-env": "^1.6.0",
-    "mocha": "^3.4.2",
+    "@babel/cli": "^7.4.4",
+    "@babel/core": "^7.4.4",
+    "@babel/plugin-transform-object-assign": "^7.2.0",
+    "@babel/plugin-transform-runtime": "^7.4.4",
+    "@babel/preset-env": "^7.4.4",
+    "@babel/register": "^7.4.4",
+    "mocha": "^6.1.4",
     "remark-parse": "^3.0.1",
     "unified": "^6.1.5",
     "unist-util-visit": "^1.1.3"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import map from 'unist-util-map';
 
 const taskListPlugin = function(options) {
@@ -7,7 +6,7 @@ const taskListPlugin = function(options) {
 
     function transformCheck(node) {
         var toggle = options.toggle || [];
-        if (node.data && toggle.includes(node.data.id)) {
+        if (node.data && toggle.indexOf(node.data.id) != -1) {
             node.checked = !node.checked;
         }
     }


### PR DESCRIPTION
Packages aren't supposed to use babel-polyfill because it pollutes the
global namespace, and babel does not allow multiple instances of
babel-polyfill. We weren't using much from the polyfill anyway.